### PR TITLE
Changed prefix to be associated to release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,21 +22,26 @@ npm install -g release-version
 Once the package has been globally installed it may be used from from any path
 
 
-
 ```shell
-release-version -r rc.2
+release-version -r 2
 ```
 given current version 1.0.0 will create version: 1.0.0-rc.2
 
 
 ```shell
-release-version -b 2 -p /path/to/project --pre rc
+release-version -r '' --pre '' -b build.420 -p /path/to/project
 ```
-version 1.0.0 will result in: 1.0.0+rc.2 on the package.json located in `/path/to/project`
+version 1.0.0 will result in: 1.0.0+build.420 on the package.json located in `/path/to/project`
 
 
 ```shell
 release-version -r alpha -b 2 --pre ''
 ```
 version 1.0.0 will result in: 1.0.0-alpha+2
+
+
+```shell
+release-version -r beta --pre ''
+```
+version 1.0.0 will result in: 1.0.0-beta
 

--- a/bin/release-version.js
+++ b/bin/release-version.js
@@ -4,20 +4,20 @@ const semverUtils = require('semver-utils');
 const jsonfile = require('jsonfile');
 jsonfile.spaces = 2;
 const argv = require('yargs')
-  .usage('Usage: $0 [-b "buildNumber"]')
-  .required('b', 'Build number is required')
-  .option('r', { alias: 'release', demand: false, default: '', describe: 'override pre-release version'})
-  .option('b', { alias: 'buildNumber', describe: 'Build Number', type: 'string'})
-  .option('pre', { alias: 'prefix', demand: false, default: 'build', describe: 'override build prefix'})
+  .usage('Usage: $0 [-r "releaseVersion"]')
+  .required('r', 'Release version is required')
+  .option('r', { alias: 'release', describe: 'Release version', type: 'string'})
+  .option('pre', { alias: 'prefix', demand: false, default: 'rc', describe: 'Change release version prefix', type: 'string'})
+  .option('b', { alias: 'build', demand: false, default: '', describe: 'Build meta data', type: 'string'})
   .option('p', { alias: 'path', demand: false, default: '.', describe: 'Path to package.json', type: 'string'})
   .option('v', { alias: 'verbose', demand: false, describe: 'logs more info', type: 'string'})
   .count('verbose')
   .help('?')
   .alias('?', 'help')
-  .example('$0 -b 12', 'creates 1.0.0+build.12')
-  .example('$0 -r rc.2', 'creates 1.0.0-rc.2')
-  .example('$0 -b 12 -r dev --pre \'\'', 'creates 1.0.0-dev+12')
-  .example('$0 -b 12 -p /path/to/project', 'creates 1.0.0+build.12')
+  .example('$0 -r 12', 'creates 1.0.0-rc.12')
+  .example('$0 -r 12 --pre alpha -b 420', 'creates 1.0.0-alpha.12+420')
+  .example('$0 -r dev --pre \'\' -b 12', 'creates 1.0.0-dev+12')
+  .example('$0 -r \'\' --pre \'\' -b build.12 -p /path/to/project', 'creates 1.0.0+build.12')
   .argv;
 
 const VERBOSE_LEVEL = argv.verbose;
@@ -40,8 +40,8 @@ if(release.length) {
   VERBOSE('release: ' + release);
 }
 
-const prefix = argv.pre.length > 0 ? argv.pre + '.' : '';
-VERBOSE('build prefix: ' + prefix);
+const prefix = argv.pre.length ? argv.pre + (argv.r.length ? '.' : '') : '';
+VERBOSE('release prefix: ' + prefix);
 
 const buildNumber = argv.b;
 DEBUG('Updating with Build Number: ' + buildNumber);
@@ -50,8 +50,8 @@ var newPackageVersion = semverUtils.stringify({
   major: parsedVersion.major,
   minor: parsedVersion.minor,
   patch: parsedVersion.patch,
-  release: release,
-  build: prefix + buildNumber
+  release: prefix + release,
+  build: buildNumber
 });
 VERBOSE('newPackageVersion: ' + newPackageVersion);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "release-version",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Append pre-release build number to version in package.json",
   "main": "index.js",
   "preferGlobal": true,


### PR DESCRIPTION
The prefix option now prefixes the release name (r option) and the build meta data (b option) is taking as provided by user.
